### PR TITLE
Cast argument of snd_seq_dump_var_event

### DIFF
--- a/sound/core/seq/oss/seq_oss_readq.c
+++ b/sound/core/seq/oss/seq_oss_readq.c
@@ -143,7 +143,7 @@ int snd_seq_oss_readq_sysex(struct seq_oss_readq *q, int dev,
 
 	if ((ev->flags & SNDRV_SEQ_EVENT_LENGTH_MASK) != SNDRV_SEQ_EVENT_LENGTH_VARIABLE)
 		return 0;
-	return snd_seq_dump_var_event(ev, readq_dump_sysex, &ctx);
+	return snd_seq_dump_var_event(ev, (snd_seq_dump_func_t) readq_dump_sysex, &ctx);
 }
 
 /*


### PR DESCRIPTION
Avoids  "error: passing argument 2 of ‘snd_seq_dump_var_event’
from incompatible pointer type" in
sound/core/seq/oss/seq_oss_readq.c:146:36