### PR TITLE
gcc-plugins: Add include required by GCC release 8

### DIFF
--- a/scripts/gcc-plugins/gcc-common.h
+++ b/scripts/gcc-plugins/gcc-common.h
@@ -104,6 +104,10 @@
 #include "predict.h"
 #include "ipa-utils.h"
 
+#if BUILDING_GCC_VERSION >= 8000
+#include "stringpool.h"
+#endif
+
 #if BUILDING_GCC_VERSION >= 4009
 #include "attribs.h"
 #include "varasm.h"


### PR DESCRIPTION
```
commit 80d172431696482d9acd8d2c4ea78fed8956e2a1 upstream.

GCC requires another #include to get the gcc-plugins to build cleanly.

Signed-off-by: Valdis Kletnieks <valdis.kletnieks@vt.edu>
Signed-off-by: Kees Cook <keescook@chromium.org>

---
 scripts/gcc-plugins/gcc-common.h | 4 ++++
 1 file changed, 4 insertions(+)
```